### PR TITLE
Remove canvas outline when focus

### DIFF
--- a/src/components/ScaffoldVuer.vue
+++ b/src/components/ScaffoldVuer.vue
@@ -2913,6 +2913,10 @@ export default {
 </style>
 
 <style lang="scss">
+canvas:focus {
+  outline: none !important;
+}
+
 .scaffold-container {
   --el-color-primary: #8300BF;
   --el-color-primary-light-5: #cd99e5;


### PR DESCRIPTION
To remove the blue outline when the canvas is focused.

The blue outline is caused by the tabindx in the following PR.
- https://github.com/alan-wu/ZincJS/pull/107