### PR TITLE
Emit emitOfflineAnnotationUpdate for Annotation Mode in Global Settings Toolbar

### DIFF
--- a/src/components/ScaffoldVuer.vue
+++ b/src/components/ScaffoldVuer.vue
@@ -2086,6 +2086,7 @@ export default {
               this.authorisedUser = undefined;
               this.offlineAnnotationEnabled = true;
             }
+            this.emitOfflineAnnotationUpdate();
             this.addAnnotationFeature();
             this.loading = false;
           });
@@ -2105,6 +2106,12 @@ export default {
         }
         this.cancelCreate();
       }
+    },
+    /**
+     * Function to emit offline annotation enabled status
+     */
+    emitOfflineAnnotationUpdate: function () {
+      this.$emit('update-offline-annotation-enabled', this.offlineAnnotationEnabled);
     },
     /**
      * @public


### PR DESCRIPTION
The event name `update-offline-annotation-enabled` with `offlineAnnotationEnabled` data is emitted to use in `mapintegratedvuer`'s global settings toolbar.

The same method as in https://github.com/ABI-Software/flatmapvuer/pull/267.